### PR TITLE
refactor: Fix deprecations and fix return type of getCard()

### DIFF
--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -36,7 +36,7 @@ class Endpoint
      /**
       * @return Array<List>
       */
-    public function list(Query $query = null): array
+    public function list(?Query $query = null): array
     {
         $res = $this->tcgdex->fetchWithParams([$this->endpoint], is_null($query) ? null : $query->params);
         if (is_null($this->listModel)) {

--- a/src/Endpoints/SetEndpoint.php
+++ b/src/Endpoints/SetEndpoint.php
@@ -24,7 +24,7 @@ class SetEndpoint extends Endpoint
         );
     }
 
-    public function getCard(string $set, string $localId): Card
+    public function getCard(string $set, string $localId): ?Card
     {
         $res = $this->tcgdex->fetch($this->endpoint, $set, $localId);
         return Model::build(new Card($this->tcgdex), $res);

--- a/src/Model/Card.php
+++ b/src/Model/Card.php
@@ -127,4 +127,6 @@ class Card extends CardResume
     public ?string $regulationMark = null;
 
     public Legal $legal;
+
+    public ?string $updated = null;
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -22,7 +22,7 @@ class Request
      * @param string $url
      * @param Array<string, string> $params
      */
-    public static function fetchWithParams(string $url, array $params = null): mixed
+    public static function fetchWithParams(string $url, ?array $params = null): mixed
     {
         if (!is_null($params)) {
             $mapped = array_map(function (string $key, string $value) {

--- a/src/TCGdex.php
+++ b/src/TCGdex.php
@@ -77,10 +77,7 @@ class TCGdex
      */
     public $lang = "en";
 
-    /**
-     * @param String|null $lang
-     */
-    public function __construct($lang = null)
+    public function __construct(?string $lang = null)
     {
         if (is_null(TCGdex::$cache)) {
             // no PSR16 implementation found, try loading the base one
@@ -232,7 +229,7 @@ class TCGdex
      * @param Array<string> $params the list of parameters to add
      * @return mixed|null
      */
-    public function fetchWithParams(array $endpoint, array $params = null)
+    public function fetchWithParams(array $endpoint, ?array $params = null)
     {
         return Request::fetchWithParams(
             Request::makePath(TCGdex::BASE_URI, $this->lang, ...$endpoint),

--- a/tests/TCGdexTest.php
+++ b/tests/TCGdexTest.php
@@ -32,10 +32,10 @@ final class TCGdexTest extends TestCase
         TCGdex::$client = new Psr18Mock("{\"id\": \"1\"}");
         $tcgdex = new TCGdex("en");
         $card1 = $tcgdex->card->get('testCache');
-        $this->assertEquals($card1->id, "1");
+        $this->assertEquals("1", $card1->id);
         TCGdex::$client = new Psr18Mock("{\"id\": \"2\"}");
         $card2 = $tcgdex->card->get('testCache');
-        $this->assertEquals($card2->id, "1");
+        $this->assertEquals("1", $card2->id);
     }
 
     public function testRealEndpoints(): void
@@ -98,6 +98,6 @@ final class TCGdexTest extends TestCase
         $tcgdex = new TCGdex("en");
         $series = $tcgdex->serie->list();
         $this->assertNotEmpty($series);
-        $this->assertNotEmpty($series[0]->fetchFullSerie());
+        $this->assertNotEmpty($series[0]->toSerie());
     }
 }

--- a/tests/TCGdexTest.php
+++ b/tests/TCGdexTest.php
@@ -73,6 +73,15 @@ final class TCGdexTest extends TestCase
         }
     }
 
+    public function testUnknownCard(): void
+    {
+        TCGdex::$client = null;
+        $tcgdex = new TCGdex("en");
+        $card = $tcgdex->set->getCard('unknownSet', 'unknownCard');
+
+        $this->assertNull($card);
+    }
+
     public function testFetchFullCardFromResume(): void
     {
         TCGdex::$client = null;


### PR DESCRIPTION
This PR fixes some deprecations triggered in php 8.4 ([source](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated))

The function getCard() can return null if no data is found. So I specified the return type and added a test.

There is still some deprecations on some attributes : 
- `Deprecated: Creation of dynamic property TCGdex\Model\Set::$abbreviation is deprecated`
- `Deprecated: Creation of dynamic property TCGdex\Model\Serie::$firstSet is deprecated`
- `Deprecated: Creation of dynamic property TCGdex\Model\Serie::$lastSet is deprecated`

As they are more complex types, this is not included in this PR